### PR TITLE
♻️ register abc set subclasses from rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ type PyUniverse = Py<_core::UniverseType>;
 
 #[pymodule]
 mod _core {
+    use pyo3::PyTypeInfo;
+
     use super::*;
 
     #[pyclass(frozen, module = "symset")]
@@ -269,5 +271,21 @@ mod _core {
                 Err(PyTypeError::new_err("not iterable"))
             }
         }
+    }
+
+    #[pymodule_init]
+    fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
+        let py = m.py();
+
+        // Register `EmptyType` and `UniverseType` as subclasses of `collections.abc.Set`
+        let abc_set = get_set_abc(py)?;
+        abc_set.call_method1("register", (EmptyType::type_object(py),))?;
+        abc_set.call_method1("register", (UniverseType::type_object(py),))?;
+
+        // Singletons for Empty and Universe
+        m.add("Empty", EmptyType::get(py))?;
+        m.add("Universe", UniverseType::get(py))?;
+
+        Ok(())
     }
 }

--- a/symset/__init__.py
+++ b/symset/__init__.py
@@ -1,20 +1,24 @@
 """Symbolic sets."""
-
-from collections.abc import Set as AbstractSet
+import sys
 from typing import Final
 
-from ._core import EmptyType, UniverseType
+from . import _core
 
-AbstractSet.register(EmptyType)  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
-AbstractSet.register(UniverseType)  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
-del AbstractSet
+__all__ = "Empty", "EmptyType", "Universe", "UniverseType"
 
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
 
-Empty: Final = EmptyType.get()
-Universe: Final = UniverseType.get()
+    EmptyType = TypeAliasType("EmptyType", _core.EmptyType)
+    UniverseType = TypeAliasType("UniverseType", _core.UniverseType)
+else:
+    from typing import TypeAlias
 
+    EmptyType: TypeAlias = _core.EmptyType
+    UniverseType: TypeAlias = _core.UniverseType
 
-__all__ = "Empty", "Universe"
+Empty: Final = _core.Empty
+Universe: Final = _core.Universe
 
 
 def __dir__() -> tuple[str, ...]:

--- a/symset/__init__.py
+++ b/symset/__init__.py
@@ -1,4 +1,5 @@
 """Symbolic sets."""
+
 import sys
 from typing import Final
 

--- a/symset/_core.pyi
+++ b/symset/_core.pyi
@@ -89,3 +89,6 @@ class UniverseType(AbstractSet[object]):
     def isdisjoint(self, other: Iterable[Any], /) -> bool: ...  # raises if not a set
     @property
     def C(self, /) -> EmptyType: ...  # noqa: N802
+
+Empty = EmptyType.get()
+Universe = UniverseType.get()

--- a/tests/test_empty.py
+++ b/tests/test_empty.py
@@ -6,7 +6,7 @@ from typing import Final, Never
 import pytest
 from hypothesis import given, strategies as st
 
-from symset import Empty, EmptyType, Universe
+from symset import Empty, Universe
 
 _EMPTY_BUILTIN_SET: Final[set[Never]] = set()
 _EMPTY_FROZENSET: Final[frozenset[Never]] = frozenset(())
@@ -15,12 +15,12 @@ _FALSY_NON_SET: Final[tuple[object, ...]] = None, False, 0, 0.0, "", b"", (), []
 
 def test_subclass_abc() -> None:
     assert isinstance(Empty, AbstractSet)
-    assert issubclass(EmptyType, AbstractSet)
+    assert issubclass(type(Empty), AbstractSet)
 
 
 def test_cannot_construct() -> None:
     with pytest.raises(TypeError):
-        _ = EmptyType()  # pyright: ignore[reportGeneralTypeIssues]
+        _ = type(Empty)()  # pyright: ignore[reportGeneralTypeIssues]
 
 
 def test_no_dict() -> None:
@@ -238,8 +238,6 @@ def test_isdisjoint() -> None:
         _ = Empty.isdisjoint(None)  # pyright: ignore[reportArgumentType]
     with pytest.raises(TypeError):
         _ = Empty.isdisjoint(object())  # pyright: ignore[reportArgumentType]
-    with pytest.raises(TypeError):
-        _ = Empty.isdisjoint(EmptyType)  # pyright: ignore[reportArgumentType]
 
 
 def test_complement() -> None:

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -16,12 +16,12 @@ _FALSY_NON_SET: Final[tuple[object, ...]] = None, False, 0, 0.0, "", b"", (), []
 
 def test_subclass_abc() -> None:
     assert isinstance(Universe, AbstractSet)
-    assert issubclass(UniverseType, AbstractSet)
+    assert issubclass(type(Universe), AbstractSet)
 
 
 def test_cannot_construct() -> None:
     with pytest.raises(TypeError):
-        _ = UniverseType()  # pyright: ignore[reportGeneralTypeIssues]
+        _ = type(Universe)()  # pyright: ignore[reportGeneralTypeIssues]
 
 
 def test_no_dict() -> None:
@@ -252,8 +252,6 @@ def test_isdisjoint() -> None:
         _ = Universe.isdisjoint(None)  # pyright: ignore[reportArgumentType]
     with pytest.raises(TypeError):
         _ = Universe.isdisjoint(object())  # pyright: ignore[reportArgumentType]
-    with pytest.raises(TypeError):
-        _ = Universe.isdisjoint(EmptyType)  # pyright: ignore[reportArgumentType]
 
 
 def test_complement() -> None:


### PR DESCRIPTION
this also publically exposes `EmptyType` and `UniverseType` as type aliases

closes #15